### PR TITLE
List available abbreviations in the dialog window.

### DIFF
--- a/texpander.sh
+++ b/texpander.sh
@@ -1,12 +1,8 @@
 #!/bin/bash
 
 base_dir="${HOME}/.texpander/"
-abbreviations=""
-for entry in "$base_dir"/*
-do
-  abbreviations+="${entry##*/}\n"
-done
-name=$(zenity --entry --title="Texpander" --text="Abbreviation\n\n$abbreviations")
+abbreviations=$(ls $base_dir | sed -e 's/\..*$//')
+name=$(zenity --entry --title="Texpander" --text="Abbreviation\n\n$abbreviations\n")
 path=$base_dir$name
 path+=".txt"
 

--- a/texpander.sh
+++ b/texpander.sh
@@ -1,7 +1,12 @@
 #!/bin/bash
 
 base_dir="${HOME}/.texpander/"
-name=$(zenity --entry --title="Texpander" --text="Abbreviation")
+abbreviations=""
+for entry in "$base_dir"/*
+do
+  abbreviations+="${entry##*/}\n"
+done
+name=$(zenity --entry --title="Texpander" --text="Abbreviation\n\n$abbreviations")
 path=$base_dir$name
 path+=".txt"
 


### PR DESCRIPTION
I find myself forgetting my abbreviations so this minor adjustment will list available abbreviations (without .txt file extension) in the dialog window. Nothing else is changed, you still have to type in the abbreviation (I like it that way because the input field is automatically focused so it's very quick to use).