### PR TITLE
Sleep shell between paste and clipboard reset

### DIFF
--- a/texpander.sh
+++ b/texpander.sh
@@ -25,6 +25,8 @@ then
     else
       xdotool key ctrl+v
     fi
+    
+    sleep 1s
 
     echo $clipboard | xclip -selection c
   else


### PR DESCRIPTION
On Ubuntu 16.04 (Lenovo Yoga 460, i7 + 8GB RAM + SSD) I had to add a slight delay between pasting the file contents and then resetting the clipboard to its original content. In its original form, this script would simply paste what was originally in the clipboard, so it stands to reason that `echo $clipboard | xclip...` would run before the `xdotool key ctrl+v` finished processing.