### PR TITLE
use realpath for the base_dir

### DIFF
--- a/texpander.sh
+++ b/texpander.sh
@@ -6,7 +6,7 @@
 pid=$(xdotool getwindowfocus getwindowpid)
 proc_name=$(cat /proc/$pid/comm)
 
-base_dir="${HOME}/.texpander"
+base_dir=$(realpath "${HOME}/.texpander")
 shopt -s globstar
 abbrvs=$(find "${base_dir}" -type f | sed "s?^${base_dir}/??g" )
 


### PR DESCRIPTION
when the base_dir is just a symlink find won't find the files. When wrapping this it will expand the symlink and find will find all files.