### PR TITLE
Remove the single trailing newline from content

### DIFF
--- a/texpander.sh
+++ b/texpander.sh
@@ -22,11 +22,11 @@ then
     clipboard=$(xsel -b -o)
 
     # Put text in primary buffer for Shift+Insert pasting
-    cat $path | xsel -p -i 
+    echo -n "$(tac "$path")" | tac | xsel -p -i 
 
     # Put text in clipboard selection for apps like Firefox that 
     # insist on using the clipboard for all pasting
-    cat $path | xsel -b -i 
+    echo -n "$(tac "$path")" | tac | xsel -b -i
 
     # Paste text into current active window
     sleep 0.3


### PR DESCRIPTION
In case users want inline content, this will remove the newline from the end of pasted content, leaving the caret immediately following the text.

Note that the tricky `tac` and re-`tac` usage is to allow users to _keep_ the newlines at the end of the file that they add themselves. My first solution was to simply use `echo -n "$(cat "$path")"`, but this trims _all_ newlines from the end, even ones the user adds to the file. For this reason, the file is read with line order reversed, taking advantage of the fact that bash command substitution using `$()` will automatically strip _all_ newlines from the end of the reverse-ordered lines (therefore the beginning of the file), and `echo -n` will not output a newline at the end, then re-reverse the text again.

Due to the craftiness, any newlines at the _beginning_ of the text content will be removed, but this is likely okay since the caret is usually properly positioned when users run the command.

## Example of New Behavior

### Without a blank line

Given a file with the content:
```
https://google.com/search?q=
```
... the pasted result will be _(`|` denoting the cursor position after insertion)_:
```
https://google.com/search?q=|
```
### With a blank line

Given a file with the content:

```
Johnny Walker

```
_(note the empty line)_... the pasted result will be:

```
Johnny Walker
|
``` 

**Whew!** That was a little rough to explain, but hopefully it makes sense.