### PR TITLE
fix "bad substitution" in configdir check

### DIFF
--- a/texpander.sh
+++ b/texpander.sh
@@ -10,8 +10,8 @@ pid=$(xdotool getwindowfocus getwindowpid)
 proc_name=$(cat /proc/$pid/comm)
 
 # If ~/.texpander directory does not exist, create it
-if [ ! -d ${$HOME}/.texpander ]; then
-    mkdir ${$HOME}/.texpander
+if [ ! -d ${HOME}/.texpander ]; then
+    mkdir ${HOME}/.texpander
 fi
 
 # Store base directory path, expand complete path using HOME environemtn variable


### PR DESCRIPTION
As a new user, I noticed this throws a warning and keeps going.
texpander.sh: line 13: ${$HOME}/.texpander: bad substitution

Non-fatal if you already have a config, so calling it from a hotkey makes it invisible.