### PR TITLE
Ignores Hidden Files

### DIFF
--- a/texpander.sh
+++ b/texpander.sh
@@ -21,7 +21,7 @@ base_dir=$(realpath "${HOME}/.texpander")
 shopt -s globstar
 
 # Find regular files in base_dir, pipe output to sed
-abbrvs=$(find "${base_dir}" -type f | sort | sed "s?^${base_dir}/??g" )
+abbrvs=$(find "${base_dir}" -not -path "${base_dir}/\.*" -type f | sort | sed "s?^${base_dir}/??g")
 
 name=$(zenity --list --title=Texpander --width=275 --height=400 --column=Abbreviations $abbrvs)
 


### PR DESCRIPTION
This PR fixes #36 by adding a -not -path "${base_dir}/\.*" switch in the find command, used to compute abbrvs. It's working on my system, so I figured I'd throw it up here.

This is useful to me because I have a ~/.texpander/.config/ folder where I put a bash script that updates all my text replacements at once from a JSON file, and those files shouldn't be indexed. If anyone wants to do a similar thing, this is a must.