### PR TITLE
fix: more robust name passing to zenity

### DIFF
--- a/texpander.sh
+++ b/texpander.sh
@@ -21,9 +21,11 @@ base_dir=$(realpath "${HOME}/.texpander")
 shopt -s globstar
 
 # Find regular files in base_dir, pipe output to sed
-abbrvs=$(find "${base_dir}" -type f | sort | sed "s?^${base_dir}/??g" )
+abbrvs=$(find "${base_dir}" -type f | sort | sed "s?^${base_dir}/??g")
 
-name=$(zenity --list --title=Texpander --width=275 --height=400 --column=Abbreviations $abbrvs)
+# 'Echo'ing the options instead of passing them directly
+# to zenity allows names like '+1' or '-1'
+name=$(echo ${abbrvs} | tr ' ' '\n' | zenity --list --title=Texpander --width=275 --height=400 --column=Abbreviations)
 
 path="${base_dir}/${name}"
 


### PR DESCRIPTION
I use Texpander to expand emojis, and the :-1: emoji was giving me trouble.

I found that this was due to the file being named `-1`, so that zenity (I use `texpander.sh`) was reading the file as an option.

`Echo`ing the options to zenity fixed the issue.