### PR TITLE
Ignore hidden . files in texpander directory

### DIFF
--- a/texpander.sh
+++ b/texpander.sh
@@ -14,7 +14,7 @@ if [ ! -d ${HOME}/.texpander ]; then
     mkdir ${HOME}/.texpander
 fi
 
-# Store base directory path, expand complete path using HOME environemtn variable
+# Store base directory path, expand complete path using HOME environment variable
 base_dir=$(realpath "${HOME}/.texpander")
 
 # Set globstar shell option (turn on) ** for filename matching glob patterns on subdirectories of ~/.texpander

--- a/texpander.sh
+++ b/texpander.sh
@@ -21,7 +21,7 @@ base_dir=$(realpath "${HOME}/.texpander")
 shopt -s globstar
 
 # Find regular files in base_dir, pipe output to sed
-abbrvs=$(find "${base_dir}" -type f | sort | sed "s?^${base_dir}/??g")
+abbrvs=$(find "${base_dir}" -type f \( ! -iname ".*" \) | sort | sed "s?^${base_dir}/??g")
 
 # 'Echo'ing the options instead of passing them directly
 # to zenity allows names like '+1' or '-1'

--- a/texpander.sh
+++ b/texpander.sh
@@ -36,12 +36,20 @@ then
     # Preserve the current value of the clipboard
     clipboard=$(xsel -b -o)
 
-    # Put text in primary buffer for Shift+Insert pasting
-    echo -n "$(cat "$path")" | xsel -p -i
-
-    # Put text in clipboard selection for apps like Firefox that 
-    # insist on using the clipboard for all pasting
-    echo -n "$(cat "$path")" | xsel -b -i
+    if [ "${path: -4}" == ".cmd" ]
+    then
+       # Put text in primary buffer for Shift+Insert pasting
+       echo -n $($(cat "$path")) | xsel -p -i
+       # Put text in clipboard selection for apps like Firefox that
+       # insist on using the clipboard for all pasting
+       echo -n $($(cat "$path")) | xsel -b -i
+    else
+       # Put text in primary buffer for Shift+Insert pasting
+       echo -n "$(cat "$path")" | xsel -p -i
+       # Put text in clipboard selection for apps like Firefox that
+       # insist on using the clipboard for all pasting
+       echo -n "$(cat "$path")" | xsel -b -i
+    fi
 
     # Paste text into current active window
     sleep 0.3

--- a/texpander.sh
+++ b/texpander.sh
@@ -25,7 +25,7 @@ abbrvs=$(find "${base_dir}" -type f \( ! -iname ".*" \) | sort | sed "s?^${base_
 
 # 'Echo'ing the options instead of passing them directly
 # to zenity allows names like '+1' or '-1'
-name=$(echo "$abbrvs" | zenity --list --title="Texpander" --width=275 --height=400 --column="Abbreviations")
+name=$(echo "$abbrvs" | zenity --list --title="Texpander" --width=275 --height=400 --column="Abbreviations" --mid-search)
 
 path="${base_dir}/${name}"
 

--- a/texpander.sh
+++ b/texpander.sh
@@ -25,7 +25,7 @@ abbrvs=$(find "${base_dir}" -type f \( ! -iname ".*" \) | sort | sed "s?^${base_
 
 # 'Echo'ing the options instead of passing them directly
 # to zenity allows names like '+1' or '-1'
-name=$(echo ${abbrvs} | tr ' ' '\n' | zenity --list --title=Texpander --width=275 --height=400 --column=Abbreviations)
+name=$(echo "$abbrvs" | zenity --list --title="Texpander" --width=275 --height=400 --column="Abbreviations")
 
 path="${base_dir}/${name}"
 


### PR DESCRIPTION
This PR fixes #36 by adding `\( ! -iname ".*" \)`. This works with subdirectories.